### PR TITLE
G7eSrXf3: Forbereder endringer i respons for narmesteleder-kall

### DIFF
--- a/src/main/kotlin/no/nav/syfo/narmesteleder/consumer/Naermesteleder.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/consumer/Naermesteleder.kt
@@ -2,7 +2,8 @@ package no.nav.syfo.narmesteleder.consumer
 
 data class Naermesteleder(
     val naermesteLederId: Long?,
-    val naermesteLederAktoerId: String,
+    val naermesteLederFnr: String?,
+    val naermesteLederAktoerId: String?,
     val orgnummer: String,
     val naermesteLederStatus: NaermesteLederStatus,
     val navn: String,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/controller/NarmesteLederMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/controller/NarmesteLederMapper.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 class NarmesteLederMapper @Inject constructor(private val aktorregisterConsumer: AktorregisterConsumer) {
 
     fun map(naermesteleder: Naermesteleder): RSNaermesteLeder {
-        val lederFodselsnummer = aktorregisterConsumer.hentFnrForAktor(naermesteleder.naermesteLederAktoerId)
+        val lederFodselsnummer = naermesteleder.naermesteLederFnr?:aktorregisterConsumer.hentFnrForAktor(naermesteleder.naermesteLederAktoerId!!)
         return RSNaermesteLeder(
                 virksomhetsnummer = naermesteleder.orgnummer,
                 navn = naermesteleder.navn,

--- a/src/main/kotlin/no/nav/syfo/narmesteleder/controller/NarmesteLederMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/narmesteleder/controller/NarmesteLederMapper.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 class NarmesteLederMapper @Inject constructor(private val aktorregisterConsumer: AktorregisterConsumer) {
 
     fun map(naermesteleder: Naermesteleder): RSNaermesteLeder {
-        val lederFodselsnummer = naermesteleder.naermesteLederFnr?:aktorregisterConsumer.hentFnrForAktor(naermesteleder.naermesteLederAktoerId!!)
+        val lederFodselsnummer = naermesteleder.naermesteLederFnr ?: aktorregisterConsumer.hentFnrForAktor(naermesteleder.naermesteLederAktoerId!!)
         return RSNaermesteLeder(
                 virksomhetsnummer = naermesteleder.orgnummer,
                 navn = naermesteleder.navn,

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/NaermesteLederControllerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/NaermesteLederControllerTest.kt
@@ -51,7 +51,8 @@ class NaermesteLederControllerTest {
 
         val leder = Naermesteleder(
                 naermesteLederId = 0L,
-                naermesteLederAktoerId = UserConstants.LEDER_AKTORID,
+                naermesteLederFnr = UserConstants.LEDER_FNR,
+                naermesteLederAktoerId = null,
                 naermesteLederStatus = NaermesteLederStatus(
                         erAktiv = true,
                         aktivFom = LocalDate.now().minusDays(1),

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/NaermesteLederMapperTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/NaermesteLederMapperTest.kt
@@ -1,0 +1,96 @@
+package no.nav.syfo.narmesteleder
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.syfo.consumer.aktorregister.AktorregisterConsumer
+import no.nav.syfo.narmesteleder.consumer.NaermesteLederStatus
+import no.nav.syfo.narmesteleder.consumer.Naermesteleder
+import no.nav.syfo.narmesteleder.controller.NarmesteLederMapper
+import no.nav.syfo.narmesteleder.controller.RSNaermesteLeder
+import no.nav.syfo.testhelper.UserConstants
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.LocalDate
+
+@ExtendWith(SpringExtension::class)
+class NaermesteLederMapperTest {
+
+
+    private val aktorregisterConsumer: AktorregisterConsumer = mockk()
+
+    private val narmesteLederMapper = NarmesteLederMapper (aktorregisterConsumer)
+
+    @Test
+    fun mapNaermesteLederMedAktorIdSuccess() {
+        val leder = Naermesteleder(
+                naermesteLederId = 0L,
+                naermesteLederFnr = null,
+                naermesteLederAktoerId = UserConstants.LEDER_AKTORID,
+                naermesteLederStatus = NaermesteLederStatus(
+                        erAktiv = true,
+                        aktivFom = LocalDate.now().minusDays(1),
+                        aktivTom = null
+                ),
+                orgnummer = UserConstants.VIRKSOMHETSNUMMER,
+                navn = "",
+                epost = null,
+                mobil = null
+        )
+
+        val rsLeder = RSNaermesteLeder(
+                virksomhetsnummer = leder.orgnummer,
+                navn = leder.navn,
+                epost = leder.epost,
+                tlf = leder.mobil,
+                erAktiv = leder.naermesteLederStatus.erAktiv,
+                aktivFom = leder.naermesteLederStatus.aktivFom,
+                aktivTom = leder.naermesteLederStatus.aktivTom,
+                fnr = UserConstants.LEDER_FNR,
+                samtykke = null,
+                sistInnlogget = null
+        )
+
+        every { aktorregisterConsumer.hentFnrForAktor(UserConstants.LEDER_AKTORID) }.returns(UserConstants.LEDER_FNR)
+
+        val rsNaermesteLeder = narmesteLederMapper.map(leder)
+
+        assertEquals(rsLeder, rsNaermesteLeder)
+    }
+
+    @Test
+    fun mapNaermesteLederMedFnrSuccess() {
+        val leder = Naermesteleder(
+                naermesteLederId = 0L,
+                naermesteLederFnr = UserConstants.LEDER_FNR,
+                naermesteLederAktoerId = null,
+                naermesteLederStatus = NaermesteLederStatus(
+                        erAktiv = true,
+                        aktivFom = LocalDate.now().minusDays(1),
+                        aktivTom = null
+                ),
+                orgnummer = UserConstants.VIRKSOMHETSNUMMER,
+                navn = "",
+                epost = null,
+                mobil = null
+        )
+
+        val rsLeder = RSNaermesteLeder(
+                virksomhetsnummer = leder.orgnummer,
+                navn = leder.navn,
+                epost = leder.epost,
+                tlf = leder.mobil,
+                erAktiv = leder.naermesteLederStatus.erAktiv,
+                aktivFom = leder.naermesteLederStatus.aktivFom,
+                aktivTom = leder.naermesteLederStatus.aktivTom,
+                fnr = UserConstants.LEDER_FNR,
+                samtykke = null,
+                sistInnlogget = null
+        )
+
+        val rsNaermesteLeder = narmesteLederMapper.map(leder)
+
+        assertEquals(rsLeder, rsNaermesteLeder)
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/NaermesteLederMapperTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/NaermesteLederMapperTest.kt
@@ -20,7 +20,7 @@ class NaermesteLederMapperTest {
 
     private val aktorregisterConsumer: AktorregisterConsumer = mockk()
 
-    private val narmesteLederMapper = NarmesteLederMapper (aktorregisterConsumer)
+    private val narmesteLederMapper = NarmesteLederMapper(aktorregisterConsumer)
 
     @Test
     fun mapNaermesteLederMedAktorIdSuccess() {

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/NaermesteLederMapperTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/NaermesteLederMapperTest.kt
@@ -17,7 +17,6 @@ import java.time.LocalDate
 @ExtendWith(SpringExtension::class)
 class NaermesteLederMapperTest {
 
-
     private val aktorregisterConsumer: AktorregisterConsumer = mockk()
 
     private val narmesteLederMapper = NarmesteLederMapper(aktorregisterConsumer)

--- a/src/test/kotlin/no/nav/syfo/narmesteleder/NarmesteLedereControllerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/narmesteleder/NarmesteLedereControllerTest.kt
@@ -54,6 +54,7 @@ class NarmesteLedereControllerTest {
 
         val narmesteLedere = listOf<Naermesteleder>(Naermesteleder(
             naermesteLederId = 0L,
+            naermesteLederFnr = null,
             naermesteLederAktoerId = UserConstants.LEDER_AKTORID,
             naermesteLederStatus = NaermesteLederStatus(
                 erAktiv = true,


### PR DESCRIPTION
syfooprest må i en periode håndtere at responsen fra syfoapi/syfooppfolgingsplan kan inneholde ENTEN `naermesteLederAktoerId` ELLER `naermesteLederFnr`. Per i dag inneholder responsen `naermesteLederAktoerId`, men etterhvert som vi tar i bruk ny narmesteleder-app, så vil responsen returnere `naermesteLederFnr` i stedet.

Når vi er helt over på bruk av ny narmesteleder-app, skal vi fjerne bruk av `naermesteLederAktoerId` slik at kun `naermesteLederFnr` brukes.